### PR TITLE
fix: download audio/wav instead of source mimetype

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -160,8 +160,8 @@ func (s *Service) GetSample(ctx context.Context, sum string) (*GetSampleResponse
 	}
 
 	var (
-		filename     = localFilename(sum, media.Mimetype)
-		rawMediaPath = filepath.Join(s.cfg.OriginalMediaLocalDir, filename)
+		filename     = wavFilename(sum)
+		rawMediaPath = filepath.Join(s.cfg.WAVMediaLocalDir, filename)
 	)
 
 	data, err := s.ls.Read(ctx, rawMediaPath)
@@ -173,7 +173,7 @@ func (s *Service) GetSample(ctx context.Context, sum string) (*GetSampleResponse
 		Media:       media,
 		Data:        data,
 		Filename:    filename,
-		ContentType: media.Mimetype,
+		ContentType: "audio/wav",
 	}, nil
 }
 


### PR DESCRIPTION
We support a bunch of different upload mimetypes, such as .m4a. This is great for uploads but for downloads we should use a more widely supported audio format. 

Rock just had his vibe killed trying to drag an .m4a into Ableton - this fixes that!