### PR TITLE
fix: increase wav quality

### DIFF
--- a/internal/encoder/ffmpeg.go
+++ b/internal/encoder/ffmpeg.go
@@ -119,13 +119,13 @@ func defaultHLSArgs(opts EncodeOpts, inputPath, outputPath string) []string {
 }
 
 func defaultWAVArgs(opts EncodeOpts, inputPath, outputPath string) []string {
-	// ffmpeg -i test.aif -acodec pcm_s16le -ac 1 -ar 16000 testaif.wav
+	// ffmpeg -i test.aif -acodec pcm_s16le -ac 2 -ar 44100 testaif.wav
 
 	return []string{
 		"-i", inputPath,
 		"-acodec", "pcm_s16le",
-		"-ac", "1",
-		"-ar", "16000",
+		"-ac", "2",
+		"-ar", "44100",
 		outputPath,
 	}
 }


### PR DESCRIPTION
Now that we're using wav files for downloads, increase the sample rate to 44.1k and make it stereo instead of mono.